### PR TITLE
Esm fixes

### DIFF
--- a/.devcontainer/editor.Dockerfile
+++ b/.devcontainer/editor.Dockerfile
@@ -3,5 +3,6 @@ FROM mcr.microsoft.com/devcontainers/javascript-node:0-16-bullseye
 # required for chartjs-node-canvas on arm machines
 # https://github.com/SeanSobey/ChartjsNodeCanvas/issues/107#issuecomment-1185438310
 # https://github.com/Automattic/node-canvas/wiki/Installation%3A-Ubuntu-and-other-Debian-based-systems
+# Since I am deploying this project to my Digital ocean droplet (x86), I don't need to install these in the actual dockerfile
 RUN sudo apt-get update && \
     sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ COPY . .
 # but as a note, prisma is included in the "production" dependencies
 # https://www.prisma.io/docs/guides/deployment/deploy-database-changes-with-prisma-migrate
 RUN npm run build && npm prune --production
-CMD [ "/usr/bin/dumb-init", "--", "node", "build/index.js" ]
+CMD [ "/usr/bin/dumb-init", "--", "node", "--es-module-specifier-resolution=node", "build/index.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM node:16-bullseye-slim
 # also install open-ssl since prisma needs it - https://github.com/prisma/prisma/issues/16232
 RUN apt-get update && apt-get install -y dumb-init openssl && rm -rf /var/lib/apt/lists/*
 
+RUN sudo apt-get update && \
+    sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev -y
+
 WORKDIR /project
 COPY package.json package-lock.json prisma ./
 RUN npm ci
@@ -13,4 +16,4 @@ COPY . .
 # but as a note, prisma is included in the "production" dependencies
 # https://www.prisma.io/docs/guides/deployment/deploy-database-changes-with-prisma-migrate
 RUN npm run build && npm prune --production
-CMD [ "/usr/bin/dumb-init", "--", "node", "--es-module-specifier-resolution=node", "build/index.js" ]
+CMD [ "/usr/bin/dumb-init", "--", "npm", "run", "start" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ FROM node:16-bullseye-slim
 # also install open-ssl since prisma needs it - https://github.com/prisma/prisma/issues/16232
 RUN apt-get update && apt-get install -y dumb-init openssl && rm -rf /var/lib/apt/lists/*
 
-RUN sudo apt-get update && \
-    sudo apt-get install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev -y
-
 WORKDIR /project
 COPY package.json package-lock.json prisma ./
 RUN npm ci

--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ A discord bot that ranks users based on their nerd score. Calculated by the numb
 
 Written in Typescript, using Prisma + Postgres. Currently deployed to my Digital Ocean Droplet.
 
+## Features
+
+Nerd Bot is configured for the following slash commands:
+
+- `/botstat` - Basic stats about the bot
+- `/vmstat` - Basic stats about the computer running the bot
+- `/stat` - Nerd stats of the user who ran the command
+- `/stat @user` - Nerd stats of the mentioned user
+- `/plt` - Plots the nerd stats over time of the user who ran the command
+- `/plt @user` - Plots the nerd stats over time of the mentioned user
+
 ## Running Locally
 
 First, create a `.env` file in the root of the project by copying the `.env.example` file. Then, fill in the values for the empty environment variables.
@@ -31,12 +42,3 @@ Inside `prisma/seed.dev.ts`, there is a small script that does some initial seed
 ```bash
 NODE_ENV=development npx prisma migrate reset
 ```
-
-## Usage
-
-Nerd Bot is configured for the following slash commands:
-
-- `/botstat` - Basic stats about the bot
-- `/vmstat` - Basic stats about the computer running the bot
-- `/stat` - Nerd stats of the user who ran the command
-- `/stat @user` - Nerd stats of the mentioned user

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "tsx watch ./src/index.ts",
     "build": "tsc",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "start": "node --es-module-specifier-resolution=node build/index.js"
   },
   "repository": {
     "type": "git",

--- a/src/client.ts
+++ b/src/client.ts
@@ -5,7 +5,7 @@ import { getCommands } from './commands.js';
 import { log } from './util/log.js';
 import chalk from 'chalk';
 import { PrismaClient } from '@prisma/client';
-import { ChartCallback, ChartJSNodeCanvas } from 'chartjs-node-canvas';
+import { ChartCallback } from 'chartjs-node-canvas';
 import { Canvas, mkCanvas } from './types/canvas.js';
 
 // incorporating the "ready" status for slightly better type inference in certain situations

--- a/src/util/getScore.ts
+++ b/src/util/getScore.ts
@@ -1,4 +1,4 @@
-import { Prisma, User } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 
 /**
  * Returns the score of a user, based on all reactions and their weights


### PR DESCRIPTION
Ci workflow for 9212dfbd988452e316f8f7dee7b6a90fe34e7e17 failed to run because [ESM does not work with namespaced directories](https://github.com/nodejs/node/issues/27408) like `date-fns`. 

I changed the run command to use the `--es-module-specifier-resolution=node` flag, which will hopefully get things working.